### PR TITLE
画像の表示を改善

### DIFF
--- a/src/molecules/S3Uploader.tsx
+++ b/src/molecules/S3Uploader.tsx
@@ -6,6 +6,7 @@ const S3Uploader: FC<{
   handleFinishedUpload: (info) => void;
 }> = ({ title, handleFinishedUpload }) => {
   const handleError = (error, text) => {
+    // eslint-disable-next-line no-console
     console.log('error', error, text);
   };
 

--- a/src/organisms/Article.tsx
+++ b/src/organisms/Article.tsx
@@ -11,13 +11,14 @@ const Article: FC<{ post: Post }> = ({ post }) => (
       query: { permalink: post.permalink },
     }}
   >
-    <div className="cursor-pointer  p-1 mb-4 md:w-1/2">
+    <div className="cursor-pointer p-1 mb-4 md:w-1/2">
       <Image
         src={`${post.thumbnailUrl ? post.thumbnailUrl : '/no-img.jpg'}`}
         alt={`${post.title}_thumbnail`}
         width={400}
         height={300}
-        layout="responsive"
+        layout="intrinsic"
+        className="object-cover"
       />
       <ArticleDetail post={post} />
     </div>

--- a/src/pages/posts/[permalink].tsx
+++ b/src/pages/posts/[permalink].tsx
@@ -90,6 +90,7 @@ const Home: FC = () => {
                   width={700}
                   height={400}
                   layout="intrinsic"
+                  className="object-contain"
                 />
               </div>
               <ShareButtons />


### PR DESCRIPTION
トップページは `object-cover`
投稿ページでは `object-contain`に変更することで画像の比率を適切にした