### PR TITLE
next.jsのバージョンを固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "easymde": "^2.14.0",
     "marked": "^2.0.0",
     "material-ui-chip-input": "^2.0.0-beta.2",
-    "next": "latest",
+    "next": "10.1.4-canary.18",
     "postcss": "^7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
https://www.gitmemory.com/issue/vercel/next.js/24605/829379863
のバグを踏んでしまったため一旦固定する